### PR TITLE
Use return values in toLocaleString example

### DIFF
--- a/store/es/index.js
+++ b/store/es/index.js
@@ -96,9 +96,9 @@ export const store = new Vuex.Store({
                 shortDesc: 'devolver la representación del array como una cadena utilizando la configuración regional.',
                 desc: 'Este es un poco loco. Devuelve la representación del array como una cadena utilizando la configuración regional. Esto es muy útil para fechas y moneda y tiene algunas extrañas abstracciones nativas, por lo que es mejor consultar los documentos al utilizarlo.',
                 example: `let date = [new Date()];<br>
-        arr.toLocaleString();<br>
-        date.toLocaleString();<br>
-        console.log(arr, date);`,
+        const arrString = arr.toLocaleString();<br>
+        const dateString = date.toLocaleString();<br>
+        console.log(arrString, dateString);`,
                 output: `"5,1,8 12/26/2017, 6:54:49 PM"`
             }
         ],

--- a/store/index.js
+++ b/store/index.js
@@ -106,9 +106,9 @@ export const store = new Vuex.Store({
         desc:
           'This one is a bit wacko. Returns a localized string representing the array and its elements. This is very useful for dates and currency and has some strange native abstractions, so best to consult the docs when using it',
         example: `let date = [new Date()];<br>
-        arr.toLocaleString();<br>
-        date.toLocaleString();<br>
-        console.log(arr, date);`,
+        const arrString = arr.toLocaleString();<br>
+        const dateString = date.toLocaleString();<br>
+        console.log(arrString, dateString);`,
         output: `"5,1,8 12/26/2017, 6:54:49 PM"`
       }
     ],


### PR DESCRIPTION
Fixed the example code for `toLocaleString(...)` so the return values (strings) are used in the `console.log()`. Doing `npm run build` updated a bunch of stuff in `dist/` but I'm not sure if we want that added to source control as well.