### PR TITLE
use const instead of let in the initial arr definition

### DIFF
--- a/src/components/AppCode.vue
+++ b/src/components/AppCode.vue
@@ -2,7 +2,7 @@
   <aside>
     <div class="usage-code usage1">
       <p>
-        <span>let arr = [5, 1, 8];</span><br>
+        <span>const arr = [5, 1, 8];</span><br>
         <span v-if="selectedUsage" 
           class="exampleoutput"
           ref="ex" 


### PR DESCRIPTION
You can use `const` instead of `let` in the initial example. This clarifies where you get a whole new array (eg. in `array.slice`), versus when you don't actually mutate `arr` but just the elements in it (eg. in `array.splice`).