### PR TITLE
Replaces Array.* with Array.prototype.*

### DIFF
--- a/src/components/methods/MethodChoice.vue
+++ b/src/components/methods/MethodChoice.vue
@@ -10,8 +10,8 @@
       </select>
     </p>
     <method-base v-show="isSelected" :urlPath="selected.name">
-      <span v-if="selected.name === 'length'" slot="title">Array.{{selected.name}}</span>
-      <span v-else slot="title">Array.{{selected.name}}()</span>
+      <span v-if="selected.name === 'length'" slot="title">Array.prototype.{{selected.name}}</span>
+      <span v-else slot="title">Array.prototype.{{selected.name}}()</span>
       <span slot="desc" v-html="selected.desc"></span>
     </method-base>
   </div>


### PR DESCRIPTION
Since these methods are all registered on `Array.prototype`, using `Array.*` may confuse newcomers with static methods on Array class.