### PR TITLE
Add end to end tests using Cypress test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ yarn-error.log*
 .AppleDouble
 .LSOverride
 
-# Icon must end with two 
+# Icon must end with two
 Icon
 # Thumbnails
 ._*
@@ -82,3 +82,7 @@ jspm_packages
 
 # Yarn Integrity file
 .yarn-integrity
+
+# Cypress test screenshots and videos
+cypress/screenshots
+cypress/videos

--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,4 @@
 {
-  "viewportHeight": 800
+  "viewportHeight": 800,
+  "defaultCommandTimeout": 6000
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
   "viewportHeight": 900,
-  "defaultCommandTimeout": 8000
+  "defaultCommandTimeout": 10000
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
-  "viewportHeight": 800,
-  "defaultCommandTimeout": 6000
+  "viewportHeight": 900,
+  "defaultCommandTimeout": 8000
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,0 +1,3 @@
+{
+  "viewportHeight": 800
+}

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -55,8 +55,19 @@ describe('array-explorer', () => {
       .then(sourceCode => {
         // show message in the command log
         cy.log('evaluating', sourceCode)
-        // evaluate the input code - we are already spying on console.log!
-        eval(sourceCode)
+        // there is one test that has hardcoded output date
+        // mock clock and pass fake "Date" object into `eval`
+        // to get the same date when called
+        var clock = Cypress.sinon.useFakeTimers(
+          new Date('12/26/2017, 6:54:49 PM').getTime()
+        )
+        {
+          // evaluate the input code - we are already spying on console.log!
+          eval('const Date = clock.Date;' + sourceCode)
+        }
+        // don't forget to restore system clock
+        // otherwise good things will not happen
+        clock.restore()
       })
 
     // confirm console.log with expected values happened in order
@@ -84,39 +95,42 @@ describe('array-explorer', () => {
     cy.contains('h1', 'JavaScript Array Explorer')
   })
 
+  // const methods = {
+  //   'add items or other arrays': [
+  //     'element/s to an array',
+  //     'elements to the end of an array',
+  //     'elements to the front of an array',
+  //     'this array to other array(s) and/or value(s)',
+  //   ],
+  //   'remove items': [
+  //     'element/s from an array',
+  //     'the last element of the array',
+  //     'the first element of the array',
+  //     'one or more elements in order for use, leaving the array as is',
+  //   ],
+  //   // skip "find items" - requires multiple parameters
+  //   'walk over items': [
+  //     'executing a function I will create for each element',
+  //     'creating a new array from each element with a function I create',
+  //     'creating an iterator object',
+  //   ],
+  //   'return a string': [
+  //     'join all elements of the array into a string',
+  //     'return a string representing the array.',
+  //     'return a localized string representing the array.',
+  //   ],
+  //   'order an array': [
+  //     'reverse the order of the array',
+  //     'sort the items of the array',
+  //   ],
+  //   'something else': [
+  //     'find the length of the array',
+  //     'fill all the elements of the array with a static value',
+  //     'copy a sequence of array elements within the array.',
+  //   ],
+  // }
   const methods = {
-    'add items or other arrays': [
-      'element/s to an array',
-      'elements to the end of an array',
-      'elements to the front of an array',
-      'this array to other array(s) and/or value(s)',
-    ],
-    'remove items': [
-      'element/s from an array',
-      'the last element of the array',
-      'the first element of the array',
-      'one or more elements in order for use, leaving the array as is',
-    ],
-    // skip "find items" - requires multiple parameters
-    'walk over items': [
-      'executing a function I will create for each element',
-      'creating a new array from each element with a function I create',
-      'creating an iterator object',
-    ],
-    'return a string': [
-      'join all elements of the array into a string',
-      'return a string representing the array.',
-      'return a localized string representing the array.',
-    ],
-    'order an array': [
-      'reverse the order of the array',
-      'sort the items of the array',
-    ],
-    'something else': [
-      'find the length of the array',
-      'fill all the elements of the array with a static value',
-      'copy a sequence of array elements within the array.',
-    ],
+    'return a string': ['return a localized string representing the array.'],
   }
 
   Object.keys(methods).forEach(method => {

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -34,6 +34,7 @@ describe('array-explorer', () => {
   })
 
   // utility functions
+  const selectMethod = choice => cy.get('#firstmethod').select(choice)
   const selectMethodOptions = choice => cy.get('#methodoptions').select(choice)
 
   const confirmInputAndOutput = () => {
@@ -95,6 +96,13 @@ describe('array-explorer', () => {
     cy.contains('h1', 'JavaScript Array Explorer')
   })
 
+  it('works in Russian', () => {
+    cy.get('[data-attr-cy="language"').select('Russian')
+    selectMethod('удалить элементы') // remove elements
+    selectMethodOptions('первый элемент массива') // first element of the array
+    confirmInputAndOutput()
+  })
+
   const methods = {
     'add items or other arrays': [
       'element/s to an array',
@@ -133,7 +141,7 @@ describe('array-explorer', () => {
   Object.keys(methods).forEach(method => {
     context(method, () => {
       beforeEach(() => {
-        cy.get('#firstmethod').select(method)
+        selectMethod(method)
       })
       methods[method].forEach(secondary => {
         it(secondary, () => {

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -2,36 +2,59 @@ describe('array-explorer', () => {
   beforeEach(() => {
     cy.visit('http://localhost:8080')
   })
+
+  // utility functions
+  const selectMethodOptions = choice => cy.get('#methodoptions').select(choice)
+  const confirmInputAndOutput = () => {
+    let output
+    cy
+      .get('.exampleoutput2')
+      .invoke('text')
+      .then(t => {
+        output = t
+      })
+    // set up spy on `console.log` before
+    // we can call `eval(input code)`
+    cy.spy(console, 'log')
+    cy.get('.usage1').then(v => {
+      const input = v.text()
+      // evaluate the input code - we are already spying on console.log!
+      eval(input)
+      // the value comes from DOM - so it needs to be
+      // converted before we can compare it to the
+      // compute value
+      expect(console.log).to.have.been.calledWith(JSON.parse(output))
+      cy
+        .get('.exampleoutput2')
+        .should('have.css', 'opacity', '1')
+        .and('contain', String(output))
+    })
+  }
+
   it('loads', () => {
     cy.contains('h1', 'JavaScript Array Explorer')
   })
+
   context('something else', () => {
-    it('shows length of an array', () => {
+    beforeEach(() => {
       cy.get('#firstmethod').select('something else')
-      cy.get('#methodoptions').select('find the length of the array')
-      let output
-      cy
-        .get('.exampleoutput2')
-        .invoke('text')
-        .then(t => {
-          output = t
-        })
-      // set up spy on `console.log` before
-      // we can call `eval(input code)`
-      cy.spy(console, 'log')
-      cy.get('.usage1').then(v => {
-        const input = v.text()
-        // evaluate the input code - we are already spying on console.log!
-        eval(input)
-        // the value comes from DOM - so it needs to be
-        // converted before we can compare it to the
-        // compute value
-        expect(console.log).to.have.been.calledWith(JSON.parse(output))
-        cy
-          .get('.exampleoutput2')
-          .should('have.css', 'opacity', '1')
-          .and('have.text', String(output))
-      })
+    })
+
+    it('shows length of an array', () => {
+      selectMethodOptions('find the length of the array')
+      confirmInputAndOutput()
+    })
+
+    it('fills array with given value', () => {
+      selectMethodOptions(
+        'fill all the elements of the array with a static value'
+      )
+      confirmInputAndOutput()
+    })
+
+    it('copy a sequence of array elements within the array', () => {
+      selectMethodOptions('copy a sequence of array elements within the array.')
+      confirmInputAndOutput()
     })
   })
 })

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -1,3 +1,5 @@
+const lolex = require('lolex')
+
 const trim = text => text.trim()
 const toDoubleQuots = text => text.replace(/'/g, '"')
 const isMultiLine = text => text.includes('\n')
@@ -29,8 +31,15 @@ const parseText = text =>
     .map(convertSingleTextLine)
 
 describe('array-explorer', () => {
+  let fakeClock
   beforeEach(() => {
-    cy.visit('http://localhost:8080')
+    cy.visit('http://localhost:8080', {
+      onBeforeLoad: win => {
+        fakeClock = lolex.install({
+          target: win,
+        })
+      },
+    })
   })
 
   // utility functions
@@ -46,6 +55,9 @@ describe('array-explorer', () => {
       .as('outputText')
       .then(parseText)
       .as('outputValues')
+      .then(() => {
+        fakeClock.tick(10000)
+      })
 
     // set up spy on `console.log` before
     // we can call `eval(input code)`
@@ -69,6 +81,7 @@ describe('array-explorer', () => {
         // don't forget to restore system clock
         // otherwise good things will not happen
         clock.restore()
+        eval(sourceCode)
       })
 
     // confirm console.log with expected values happened in order

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -5,6 +5,7 @@ describe('array-explorer', () => {
 
   // utility functions
   const selectMethodOptions = choice => cy.get('#methodoptions').select(choice)
+  const toDouble = text => text.replace(/'/g, '"')
   const confirmInputAndOutput = () => {
     let output
     cy
@@ -23,11 +24,12 @@ describe('array-explorer', () => {
       // the value comes from DOM - so it needs to be
       // converted before we can compare it to the
       // compute value
-      expect(console.log).to.have.been.calledWith(JSON.parse(output))
+      // TODO remove comments from the output
+      expect(console.log).to.have.been.calledWith(JSON.parse(toDouble(output)))
       cy
         .get('.exampleoutput2')
         .should('have.css', 'opacity', '1')
-        .and('contain', String(output))
+        .and('contain', output)
     })
   }
 
@@ -35,26 +37,52 @@ describe('array-explorer', () => {
     cy.contains('h1', 'JavaScript Array Explorer')
   })
 
-  context('something else', () => {
-    beforeEach(() => {
-      cy.get('#firstmethod').select('something else')
-    })
+  const methods = {
+    'add items or other arrays': [
+      'element/s to an array',
+      'elements to the end of an array',
+      'elements to the front of an array',
+      'this array to other array(s) and/or value(s)',
+    ],
+    'remove items': [
+      'element/s from an array',
+      'the last element of the array',
+      'the first element of the array',
+      'one or more elements in order for use, leaving the array as is',
+    ],
+    // skip "find items" - requires multiple parameters
+    'walk over items': [
+      'executing a function I will create for each element',
+      'creating a new array from each element with a function I create',
+      'creating an iterator object',
+    ],
+    'return a string': [
+      'join all elements of the array into a string',
+      'return a string representing the array.',
+      'return a localized string representing the array.',
+    ],
+    'order an array': [
+      'reverse the order of the array',
+      'sort the items of the array',
+    ],
+    'something else': [
+      'find the length of the array',
+      'fill all the elements of the array with a static value',
+      'copy a sequence of array elements within the array.',
+    ],
+  }
 
-    it('shows length of an array', () => {
-      selectMethodOptions('find the length of the array')
-      confirmInputAndOutput()
-    })
-
-    it('fills array with given value', () => {
-      selectMethodOptions(
-        'fill all the elements of the array with a static value'
-      )
-      confirmInputAndOutput()
-    })
-
-    it('copy a sequence of array elements within the array', () => {
-      selectMethodOptions('copy a sequence of array elements within the array.')
-      confirmInputAndOutput()
+  Object.keys(methods).forEach(method => {
+    context(method, () => {
+      beforeEach(() => {
+        cy.get('#firstmethod').select(method)
+      })
+      methods[method].forEach(secondary => {
+        it(secondary, () => {
+          selectMethodOptions(secondary)
+          confirmInputAndOutput()
+        })
+      })
     })
   })
 })

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -1,0 +1,37 @@
+describe('array-explorer', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:8080')
+  })
+  it('loads', () => {
+    cy.contains('h1', 'JavaScript Array Explorer')
+  })
+  context('something else', () => {
+    it('shows length of an array', () => {
+      cy.get('#firstmethod').select('something else')
+      cy.get('#methodoptions').select('find the length of the array')
+      let output
+      cy
+        .get('.exampleoutput2')
+        .invoke('text')
+        .then(t => {
+          output = t
+        })
+      // set up spy on `console.log` before
+      // we can call `eval(input code)`
+      cy.spy(console, 'log')
+      cy.get('.usage1').then(v => {
+        const input = v.text()
+        // evaluate the input code - we are already spying on console.log!
+        eval(input)
+        // the value comes from DOM - so it needs to be
+        // converted before we can compare it to the
+        // compute value
+        expect(console.log).to.have.been.calledWith(JSON.parse(output))
+        cy
+          .get('.exampleoutput2')
+          .should('have.css', 'opacity', '1')
+          .and('have.text', String(output))
+      })
+    })
+  })
+})

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -95,42 +95,39 @@ describe('array-explorer', () => {
     cy.contains('h1', 'JavaScript Array Explorer')
   })
 
-  // const methods = {
-  //   'add items or other arrays': [
-  //     'element/s to an array',
-  //     'elements to the end of an array',
-  //     'elements to the front of an array',
-  //     'this array to other array(s) and/or value(s)',
-  //   ],
-  //   'remove items': [
-  //     'element/s from an array',
-  //     'the last element of the array',
-  //     'the first element of the array',
-  //     'one or more elements in order for use, leaving the array as is',
-  //   ],
-  //   // skip "find items" - requires multiple parameters
-  //   'walk over items': [
-  //     'executing a function I will create for each element',
-  //     'creating a new array from each element with a function I create',
-  //     'creating an iterator object',
-  //   ],
-  //   'return a string': [
-  //     'join all elements of the array into a string',
-  //     'return a string representing the array.',
-  //     'return a localized string representing the array.',
-  //   ],
-  //   'order an array': [
-  //     'reverse the order of the array',
-  //     'sort the items of the array',
-  //   ],
-  //   'something else': [
-  //     'find the length of the array',
-  //     'fill all the elements of the array with a static value',
-  //     'copy a sequence of array elements within the array.',
-  //   ],
-  // }
   const methods = {
-    'return a string': ['return a localized string representing the array.'],
+    'add items or other arrays': [
+      'element/s to an array',
+      'elements to the end of an array',
+      'elements to the front of an array',
+      'this array to other array(s) and/or value(s)',
+    ],
+    'remove items': [
+      'element/s from an array',
+      'the last element of the array',
+      'the first element of the array',
+      'one or more elements in order for use, leaving the array as is',
+    ],
+    // skip "find items" - requires multiple parameters
+    'walk over items': [
+      'executing a function I will create for each element',
+      'creating a new array from each element with a function I create',
+      'creating an iterator object',
+    ],
+    'return a string': [
+      'join all elements of the array into a string',
+      'return a string representing the array.',
+      'return a localized string representing the array.',
+    ],
+    'order an array': [
+      'reverse the order of the array',
+      'sort the items of the array',
+    ],
+    'something else': [
+      'find the length of the array',
+      'fill all the elements of the array with a static value',
+      'copy a sequence of array elements within the array.',
+    ],
   }
 
   Object.keys(methods).forEach(method => {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,0 +1,17 @@
+// ***********************************************************
+// This example plugins/index.js can be used to load plugins
+//
+// You can change the location of this file or turn off loading
+// the plugins file with the 'pluginsFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/plugins-guide
+// ***********************************************************
+
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
+
+module.exports = (on, config) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add("login", (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This is will overwrite an existing command --
+// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "dev": "webpack-dev-server --inline --progress --config build/webpack.dev.conf.js",
     "start": "npm run dev",
-    "build": "node build/build.js"
+    "build": "node build/build.js",
+    "test": "cypress run",
+    "test:gui": "cypress open"
   },
   "dependencies": {
     "gsap": "^1.20.3",
@@ -50,7 +52,8 @@
     "webpack": "^3.6.0",
     "webpack-bundle-analyzer": "^2.9.0",
     "webpack-dev-server": "^2.9.1",
-    "webpack-merge": "^4.1.0"
+    "webpack-merge": "^4.1.0",
+    "cypress": "1.4.1"
   },
   "engines": {
     "node": ">= 4.0.0",
@@ -62,3 +65,4 @@
     "not ie <= 8"
   ]
 }
+

--- a/package.json
+++ b/package.json
@@ -31,10 +31,12 @@
     "chalk": "^2.0.1",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.28.0",
+    "cypress": "1.4.1",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^1.1.4",
     "friendly-errors-webpack-plugin": "^1.6.1",
     "html-webpack-plugin": "^2.30.1",
+    "lolex": "^2.3.1",
     "node-notifier": "^5.1.2",
     "optimize-css-assets-webpack-plugin": "^3.2.0",
     "ora": "^1.2.0",
@@ -52,8 +54,7 @@
     "webpack": "^3.6.0",
     "webpack-bundle-analyzer": "^2.9.0",
     "webpack-dev-server": "^2.9.1",
-    "webpack-merge": "^4.1.0",
-    "cypress": "1.4.1"
+    "webpack-merge": "^4.1.0"
   },
   "engines": {
     "node": ">= 4.0.0",
@@ -65,4 +66,3 @@
     "not ie <= 8"
   ]
 }
-

--- a/src/components/AppCode.vue
+++ b/src/components/AppCode.vue
@@ -116,7 +116,7 @@ export default {
         })
         setTimeout(() => {
           this.typeOut()
-        }, 500)
+        }, 3000)
       }
     }
   }

--- a/src/components/AppCode.vue
+++ b/src/components/AppCode.vue
@@ -116,7 +116,7 @@ export default {
         })
         setTimeout(() => {
           this.typeOut()
-        }, 3000)
+        }, 500)
       }
     }
   }

--- a/src/components/LocaleSwitcher.vue
+++ b/src/components/LocaleSwitcher.vue
@@ -2,8 +2,8 @@
   <div class="localization-dropdown">
     <a href="https://sdras.github.io/object-explorer/"><em>Object Explorer</em></a>
     <br>
-    Language: 
-    <select v-model="selectedLanguage">
+    Language:
+    <select v-model="selectedLanguage" data-attr-cy="language">
       <option v-for="(val, key) in languages" :value="key">{{val.long}}</option>
     </select>
   </div>

--- a/store/en/index.js
+++ b/store/en/index.js
@@ -8,7 +8,7 @@ export default {
         desc: 'Adds and/or removes elements from an array.',
         example: `arr.splice(2, 0, 'tacos');<br>
         console.log(arr);`,
-        output: `[5, 1, 'tacos', 8]`
+        output: `[5, 1, 'tacos', 8]`,
       },
       {
         name: 'push',
@@ -17,7 +17,7 @@ export default {
           'Adds one or more elements to the end of an array and returns the new length of the array.',
         example: `arr.push(2);<br>
         console.log(arr);`,
-        output: '[5, 1, 8, 2]'
+        output: '[5, 1, 8, 2]',
       },
       {
         name: 'unshift',
@@ -26,7 +26,7 @@ export default {
           'Adds one or more elements to the front of an array and returns the new length of the array.',
         example: `arr.unshift(2, 7);<br>
         console.log(arr);`,
-        output: '[2, 7, 5, 1, 8]'
+        output: '[2, 7, 5, 1, 8]',
       },
       {
         name: 'concat',
@@ -36,8 +36,8 @@ export default {
         example: `let arr2 = ['a', 'b', 'c'];<br>
         let arr3 = arr.concat(arr2);<br>
         console.log(arr3);`,
-        output: `[5, 1, 8, 'a', 'b', 'c']`
-      }
+        output: `[5, 1, 8, 'a', 'b', 'c']`,
+      },
     ],
     removing: [
       {
@@ -46,7 +46,7 @@ export default {
         desc: 'Adds and/or removes elements from an array.',
         example: `arr.splice(2, 1);<br>
         console.log(arr);`,
-        output: `[5, 1]`
+        output: `[5, 1]`,
       },
       {
         name: 'pop',
@@ -55,7 +55,7 @@ export default {
           'Removes the last element from an array and returns that element.',
         example: `arr.pop();<br>
         console.log(arr);`,
-        output: `[5, 1]`
+        output: `[5, 1]`,
       },
       {
         name: 'shift',
@@ -64,7 +64,7 @@ export default {
           'Removes the first element from an array and returns that element.',
         example: `arr.shift();<br>
         console.log(arr);`,
-        output: `[1, 8]`
+        output: `[1, 8]`,
       },
       {
         name: 'slice',
@@ -76,8 +76,8 @@ export default {
         console.log(arr);<br>
         console.log(slicedArr);`,
         output: `[5, 1, 8]<br>
-        [1, 8]`
-      }
+        [1, 8]`,
+      },
     ],
     string: [
       {
@@ -86,14 +86,14 @@ export default {
         desc: `Joins all elements of an array into a string. You can join it together as is or with something in between, <code>elements.join(' -
           ')</code> gives you <code>foo-bar</code>`,
         example: `console.log(arr.join());`,
-        output: `"5,1,8"`
+        output: `"5,1,8"`,
       },
       {
         name: 'toString',
         shortDesc: 'return a string representing the array.',
         desc: 'Returns a string representing the array and its elements.',
         example: `console.log(arr.toString());`,
-        output: `"5,1,8"`
+        output: `"5,1,8"`,
       },
       {
         name: 'toLocaleString',
@@ -103,9 +103,11 @@ export default {
         example: `let date = [new Date()];<br>
         const arrString = arr.toLocaleString();<br>
         const dateString = date.toLocaleString();<br>
-        console.log(arrString, dateString);`,
-        output: `"5,1,8 12/26/2017, 6:54:49 PM"`
-      }
+        console.log(arrString);<br>
+        console.log(dateString);`,
+        output: `"5,1,8"<br>
+        "12/26/2017, 6:54:49 PM"`,
+      },
     ],
     ordering: [
       {
@@ -115,7 +117,7 @@ export default {
           'Reverses the order of the elements of an array in place — the first becomes the last, and the last becomes the first.',
         example: `arr.reverse();<br>
         console.log(arr);`,
-        output: `[8, 1, 5]`
+        output: `[8, 1, 5]`,
       },
       {
         name: 'sort',
@@ -125,8 +127,8 @@ export default {
         <strong>Important note:</strong> If compareFunction is not supplied, elements are sorted by converting them to strings and comparing strings in Unicode code point order. For example, "Banana" comes before "cherry". In a numeric sort, 9 comes before 80, but because numbers are converted to strings, "80" comes before "9" in Unicode order. The docs have more information to clarify.`,
         example: `arr.sort();<br>
         console.log(arr);`,
-        output: `[1, 5, 8]`
-      }
+        output: `[1, 5, 8]`,
+      },
     ],
     other: [
       {
@@ -134,7 +136,7 @@ export default {
         shortDesc: 'find the length of the array',
         desc: 'Returns the number of elements in that array.',
         example: `console.log(arr.length);`,
-        output: `3`
+        output: `3`,
       },
       {
         name: 'fill',
@@ -143,7 +145,7 @@ export default {
           'Fills all the elements of an array from a start index to an end index with a static value.',
         example: `arr.fill(2);<br>
         console.log(arr);`,
-        output: `[2, 2, 2]`
+        output: `[2, 2, 2]`,
       },
       {
         name: 'copyWithin',
@@ -152,8 +154,8 @@ export default {
           'Copies a sequence of array elements within the array. You can specify either just the ending element (where begin will default to zero) or both the beginning and the end, comma-separated.',
         example: `arr.copyWithin(1);<br>
         console.log(arr);`,
-        output: `[5, 5, 1]`
-      }
+        output: `[5, 5, 1]`,
+      },
     ],
     iterate: [
       {
@@ -166,7 +168,7 @@ export default {
         });`,
         output: `5<br>
         1<br>
-        8`
+        8`,
       },
       {
         name: 'map',
@@ -176,7 +178,7 @@ export default {
           'Creates a new array with the results of calling a provided function on every element in this array.',
         example: `let map = arr.map(x => x + 1);<br>
         console.log(map);`,
-        output: `[6, 2, 9]`
+        output: `[6, 2, 9]`,
       },
       {
         name: 'entries',
@@ -187,8 +189,8 @@ export default {
         console.log(iterator.next().value);`,
         output: `[0, 5]<br>
         <span class="comment">// the 0 is the index,</span><br>
-        <span class="comment">// the 5 is the first number</span>`
-      }
+        <span class="comment">// the 5 is the first number</span>`,
+      },
     ],
     find: {
       single: [
@@ -198,7 +200,7 @@ export default {
           desc:
             'Determines whether an array contains a certain element, returning true or false as appropriate.',
           example: `console.log(arr.includes(1));`,
-          output: `true`
+          output: `true`,
         },
         {
           name: 'indexOf',
@@ -206,7 +208,7 @@ export default {
           desc:
             'Returns the first index at which a given element can be found in the array, or -1 if it is not present.',
           example: `console.log(arr.indexOf(5));`,
-          output: `0`
+          output: `0`,
         },
         {
           name: 'lastIndexOf',
@@ -214,7 +216,7 @@ export default {
           desc:
             'Returns the last (greatest) index of an element within the array equal to the specified value, or -1 if none is found.',
           example: `console.log(arr.lastIndexOf(5));`,
-          output: `0`
+          output: `0`,
         },
         {
           name: 'find',
@@ -223,7 +225,7 @@ export default {
             'Returns the found value in the array, if an element in the array satisfies the provided testing function or undefined if not found. Similar to <code>findIndex()</code>, but it returns the item instead of the index.',
           example: `let isTiny = (el) => el < 2;<br>
           console.log(arr.find(isTiny));`,
-          output: `1`
+          output: `1`,
         },
         {
           name: 'findIndex',
@@ -232,7 +234,7 @@ export default {
             'Returns the index of the first element in the array that satisfies the provided testing function. Otherwise -1 is returned. Similar to <code>find()</code>, but it returns the index instead of the item.',
           example: `let isBig = (el) => el > 6;<br>
           console.log(arr.findIndex(isBig));`,
-          output: `2`
+          output: `2`,
         },
         {
           name: 'reduce',
@@ -241,7 +243,7 @@ export default {
             'Apply a function against an accumulator and each value of the array (from left-to-right) as to reduce it to a single value.',
           example: `let reducer = (a, b) => a + b;<br>
           console.log(arr.reduce(reducer));`,
-          output: `14`
+          output: `14`,
         },
         {
           name: 'reduceRight',
@@ -251,8 +253,8 @@ export default {
           example: `[arr, [0, 1]].reduceRight((a, b) => {<br>
           <span>&nbsp;&nbsp;</span>return a.concat(b)<br>
           }, [])`,
-          output: `[0, 1, 5, 1, 8]`
-        }
+          output: `[0, 1, 5, 1, 8]`,
+        },
       ],
       many: [
         {
@@ -262,7 +264,7 @@ export default {
             'Creates a new array with all of the elements of this array for which the provided filtering function returns true.',
           example: `let filtered = arr.filter(el => el > 4);<br>
           console.log(filtered)`,
-          output: `[5, 8]`
+          output: `[5, 8]`,
         },
         {
           name: 'every',
@@ -271,7 +273,7 @@ export default {
             'Returns true if every element in this array satisfies the provided testing function.',
           example: `let isSmall = (el) => el < 10;<br>
           console.log(arr.every(isSmall));`,
-          output: `true`
+          output: `true`,
         },
         {
           name: 'some',
@@ -280,9 +282,9 @@ export default {
             'Returns true if at least one element in this array satisfies the provided testing function.',
           example: `let biggerThan4 = (el) => el > 4;<br>
           console.log(arr.some(biggerThan4));`,
-          output: `true`
-        }
-      ]
-    }
-  }
+          output: `true`,
+        },
+      ],
+    },
+  },
 }


### PR DESCRIPTION
Hi,

I have noticed that the project lacks any tests and took liberty to write a few using Cypress.io test runner. The tests are exercising all methods, except for `find` (because there are 2 arguments, not one like other tests). Each test grabs the code from the input, evaluates it and compares to the shown output. Here is example of the test runner going through tests when opened with `npm run test:gui`

<img width="1258" alt="faked-date" src="https://user-images.githubusercontent.com/2212006/34705537-0cf6318c-f4cf-11e7-84c5-f55ef91568d7.png">

The test runner in action in this video https://youtu.be/6-nI6lW3zM0

![array-explorer-start](https://user-images.githubusercontent.com/2212006/34705633-c7d76da4-f4cf-11e7-92f2-8d5a09890692.gif)

Two new script commands

* `npm run test:gui` to open Cypress GUI and see the tests locally.
* `npm test` to run Cypress without GUI (good for CI)

Both assume the app is running at `http://localhost:8080`